### PR TITLE
JSON.parse is unnecessary and throws an error

### DIFF
--- a/server/api/api.js
+++ b/server/api/api.js
@@ -4,8 +4,6 @@ var fs = require('fs')
 
 module.exports = {
   create: function (req, res) {
-    var data = JSON.parse(req.body.data)
-
     // which user does this belong to??
     if (req.user) {
       data.author = req.user.username
@@ -31,7 +29,6 @@ module.exports = {
   getImage: getImage,
 
   postFeedback: function (req, res) {
-    var data = JSON.parse(req.body.data)
     database.addFeedback(data, function (err, response) {
       if (err) throw new Error(err)
 


### PR DESCRIPTION
When using body parser in your server file you don't need to JSON.parse.  Doing so will error and break since a Javascript Object is not JSON.