### PR TITLE
Update ColorPicker.jsx for consitency to wheel colors

### DIFF
--- a/src/components/Editor/small/ColorPicker.jsx
+++ b/src/components/Editor/small/ColorPicker.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 var colors = {
-  red: '#CC0000',
+  red: '#D02516',
   blue: '#4285F4',
   brown: '#B15911',
   green: '#34A853',


### PR DESCRIPTION
I changed the red color to #d02516 in order to have consitency with the red color I proposed for the nap-chart repo.

This color should fit better than the one before as it is a shade of the original red. Additionally, it is dark enough to be relatively easily viewable with red glasses